### PR TITLE
Fixes

### DIFF
--- a/lrtools/tests/test_fns.py
+++ b/lrtools/tests/test_fns.py
@@ -1,19 +1,42 @@
-from optimizer.tools.newfunctions import *
+from lrtools.ciwrapper import *
+from optimizer.hf_lda import *
 import pyci
 
-def test_get_sd_pyci():
-    nbasis = 5
-    alphas = [[0,1,3], [1,2,3], [0,1,2], [0,2,3], [0,1,3]]
-    betas = [[5,6,7], [5,7,8], [6,7,8], [5,8,9], [5,6,8]]
-    vec = get_ci_sd_pyci(nbasis, alphas, betas)
-    assert vec == [235, 430, 455, 813, 363]
 
-def test_get_dets_pyci():
-    # Using PyCI to compute FCI energy
+def test_get_ci_sd_pyci():
+    nbasis = 5
     na = 2
     nb = 1
-    nbasis = 3
-    wfn = pyci.FullCIWfn(nbasis, na, nb)
-    alphas, betas = get_dets_pyci(wfn)
+    wfn = pyci.FullCIWavefunction(nbasis, na, nb)
+    sd_vec = get_ci_sd_pyci(nbasis, wfn)
+    assert sd_vec == [35, 67, 131, 259, 515, 37, 69,
+                      133, 261, 517, 38, 70, 134, 262,
+                      518, 41, 73, 137, 265, 521, 42, 74,
+                      138, 266, 522, 44, 76, 140, 268, 524,
+                      49, 81, 145, 273, 529, 50, 82, 146, 274,
+                      530, 52, 84, 148, 276, 532, 56, 88, 152, 280, 536]
+#test_get_ci_sd_pyci()
 
-test_get_dets_pyci()
+
+def test_FCI():
+    mol = IOData(numbers=np.array([2]), coordinates=np.array([[0., 0., 0.]]))
+    obasis = get_gobasis(mol.coordinates, mol.numbers, 'cc-pvdz')
+    na = 1
+    nb = 1
+    kin, natt, olp, er = prepare_integrals(mol, obasis)
+    hf_energy, core_energy, orbs = compute_hf(mol, obasis, na, nb, kin, natt, er, olp)
+    (one_mo,), (two_mo,) = transform_integrals(kin + natt, er, 'tensordot', orbs[0])
+    cienergy, cicoeffs, civec = compute_FCI(obasis.nbasis, core_energy, one_mo, two_mo,
+                                            na, nb)
+    wfn = pyci.FullCIWavefunction(obasis.nbasis, na, nb)
+    two_mo = two_mo.reshape(two_mo.shape[0]**2, two_mo.shape[1]**2)
+    ciham = pyci.Hamiltonian(core_energy, one_mo, two_mo)
+    solver = pyci.SparseSolver(wfn, ciham)
+    solver()
+    cienergy0 = solver.eigenvalues()[0]
+    cicoeffs0 = solver.eigenvectors().flatten()
+    print cienergy
+    assert abs(cienergy + 2.88759483109) < 1e-11
+    assert cienergy0 == cienergy
+    assert (abs(cicoeffs0 - cicoeffs) < 1e-10).all()
+#test_FCI()

--- a/optimizer/minimizer.py
+++ b/optimizer/minimizer.py
@@ -231,6 +231,7 @@ class FullErfOptimizer(ErfGauOptimizer):
         else:
             return self.mu_energy - energy_exp
 
+
 class FullGauOptimizer(ErfGauOptimizer):
     """
     Variational optimizer for the erfgau potential from FCI expansion
@@ -258,6 +259,7 @@ class FullGauOptimizer(ErfGauOptimizer):
         ErfGauOptimizer.__init__(self, nbasis, core_energy, modintegrals, refintegrals,
                                  na, nb, ncore, mu)
         self.ccounts = None
+        self.cicoeffs = None
 
     def compute_energy(self, pars):
         """Function for Scipy to compute the energy"""
@@ -288,6 +290,7 @@ class FullGauOptimizer(ErfGauOptimizer):
             cienergy, cicoeffs, civec = compute_FCI(self.nbasis, self.core_energy,
                                                     one_no, two_no,
                                                     self.na, self.nb)
+            self.cicoeffs = cicoeffs
             (dm1,), (dm2,) = density_matrix(cicoeffs, civec, self.nbasis)
             energy_exp = np.einsum('ij,ij', one_no_full, dm1)\
                         + 0.5*np.einsum('ijkl, ijkl', two_no_full, dm2)
@@ -368,6 +371,7 @@ class FullGauOptimizer(ErfGauOptimizer):
         fmin = result[0]
         emin = result[1]
         return result
+
 
 class FullErfGauOptimizer(ErfGauOptimizer):
     """

--- a/optimizer/tests/test_minimizer.py
+++ b/optimizer/tests/test_minimizer.py
@@ -152,7 +152,7 @@ def test_erfgau_lr():
     print "energy", energy
     print "mu energy", optimizer.mu_energy
 
-#test_erfgau_lr()
+test_erfgau_lr()
 
 def test_erfgau_truc():
     """
@@ -186,4 +186,4 @@ def test_erfgau_truc():
     energy = optimizer.compute_energy(cpars)
     print "energy", energy
     print "mu energy", optimizer.mu_energy
-test_erfgau_truc()
+#test_erfgau_truc()

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def readme():
 
 setup(
     name='LROptimizer',
-    version=get_version(),
+    version='0.0.1b',
     description='Optimizer of Long-Range model Hamiltonians.',
     long_description=readme(),
     author='Cristina E. Gonz\'alez-Espinoza',


### PR DESCRIPTION
Few fixes:
1) Delete Hamiltonian and wfn after finishing CI calculations
2) Added option to choose solver: dense or sparse. If nothing is specified it will select one according to the number of determinants. Less than 50 000 determinants problem will use the Dense solver. For more than 50 000 determinants the sparse solver is used.